### PR TITLE
added required fields all to serializer

### DIFF
--- a/votes/serializers.py
+++ b/votes/serializers.py
@@ -18,3 +18,4 @@ class VoteSerializer(serializers.ModelSerializer):
     @transaction.atomic
     class Meta:
         model = Vote
+        fields = '__all__'


### PR DESCRIPTION
"Creating a ModelSerializer without either the 'fields' attribute or the 'exclude' attribute has been deprecated since 3.3.0, and is now disallowed" so i added it